### PR TITLE
feat: add Prometheus metrics for observability

### DIFF
--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -76,3 +76,12 @@ protos = { path = "../protos" }
 utils = { path = "../utils" }
 
 clap = { version = "4.5.6", features=["derive"]}
+
+# Metrics
+metrics = "0.24"
+metrics-exporter-prometheus = "0.16"
+
+# HTTP server for metrics endpoint
+hyper = { version = "1.5", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"

--- a/apps/src/metrics_server.rs
+++ b/apps/src/metrics_server.rs
@@ -1,0 +1,76 @@
+//! Prometheus metrics HTTP server for Ruuster.
+//!
+//! Exposes a `/metrics` endpoint for Prometheus scraping.
+
+use http_body_util::Full;
+use hyper::body::Bytes;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tracing::{error, info};
+
+/// Initialize the Prometheus metrics recorder and return the handle for rendering metrics.
+pub fn init_metrics_recorder() -> PrometheusHandle {
+    PrometheusBuilder::new()
+        .install_recorder()
+        .expect("Failed to install Prometheus metrics recorder")
+}
+
+/// Handle incoming HTTP requests - only `/metrics` endpoint is supported.
+async fn handle_request(
+    req: Request<hyper::body::Incoming>,
+    handle: PrometheusHandle,
+) -> Result<Response<Full<Bytes>>, Infallible> {
+    let response = match req.uri().path() {
+        "/metrics" => {
+            let metrics = handle.render();
+            Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", "text/plain; charset=utf-8")
+                .body(Full::new(Bytes::from(metrics)))
+                .unwrap()
+        }
+        "/health" => Response::builder()
+            .status(StatusCode::OK)
+            .body(Full::new(Bytes::from("OK")))
+            .unwrap(),
+        _ => Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Full::new(Bytes::from("Not Found")))
+            .unwrap(),
+    };
+    Ok(response)
+}
+
+/// Start the metrics HTTP server on the given address.
+///
+/// This function spawns a background task that serves the `/metrics` endpoint.
+pub async fn start_metrics_server(
+    addr: SocketAddr,
+    handle: PrometheusHandle,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let listener = TcpListener::bind(addr).await?;
+    info!("Metrics server listening on http://{}/metrics", addr);
+
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let io = TokioIo::new(stream);
+        let handle = handle.clone();
+
+        tokio::spawn(async move {
+            let service = service_fn(move |req| {
+                let handle = handle.clone();
+                handle_request(req, handle)
+            });
+
+            if let Err(err) = http1::Builder::new().serve_connection(io, service).await {
+                error!("Error serving metrics connection: {:?}", err);
+            }
+        });
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,19 +22,23 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-# Uncomment the following section to enable Grafana for visualization
-# grafana:
-#   image: grafana/grafana:latest
-#   ports:
-#     - "3000:3000"
-#   environment:
-#     - GF_SECURITY_ADMIN_USER=admin
-#     - GF_SECURITY_ADMIN_PASSWORD=admin
-#     - GF_USERS_ALLOW_SIGN_UP=false
-#   volumes:
-#     - grafana-data:/var/lib/grafana
-#   depends_on:
-#     - prometheus
+  grafana:
+    image: grafana/grafana:latest
+    profiles:
+      - monitoring
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus
 
-# volumes:
-#   grafana-data:
+volumes:
+  grafana-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,34 @@ services:
       - "16686:16686"
       - "14268:14268"
       - "4317:4317"
+
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+# Uncomment the following section to enable Grafana for visualization
+# grafana:
+#   image: grafana/grafana:latest
+#   ports:
+#     - "3000:3000"
+#   environment:
+#     - GF_SECURITY_ADMIN_USER=admin
+#     - GF_SECURITY_ADMIN_PASSWORD=admin
+#     - GF_USERS_ALLOW_SIGN_UP=false
+#   volumes:
+#     - grafana-data:/var/lib/grafana
+#   depends_on:
+#     - prometheus
+
+# volumes:
+#   grafana-data:

--- a/exchanges/Cargo.toml
+++ b/exchanges/Cargo.toml
@@ -18,5 +18,6 @@ serde = { version = "1.0.201", features = ["derive"] }
 serde_json = "1.0.117"
 lazy_static = "1.4.0"
 env_logger = "0.11.3"
+metrics = "0.24"
 
 internals = { path = '../internals' }

--- a/grafana/dashboards/ruuster.json
+++ b/grafana/dashboards/ruuster.json
@@ -1,0 +1,749 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "ruuster_queues_count",
+          "refId": "A"
+        }
+      ],
+      "title": "Queues",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "ruuster_exchanges_count",
+          "refId": "A"
+        }
+      ],
+      "title": "Exchanges",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "sum(ruuster_messages_produced_total)",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Produced",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "purple", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "sum(ruuster_messages_consumed_total)",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Consumed",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "ruuster_messages_acked_total",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Acked",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "orange", "value": null },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "sum(ruuster_messages_nacked_total)",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Nacked",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 8,
+      "panels": [],
+      "title": "Message Throughput",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 9,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(ruuster_messages_produced_total[$__rate_interval])) by (exchange)",
+          "legendFormat": "{{exchange}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Messages Produced (rate/sec)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(ruuster_messages_consumed_total[$__rate_interval])) by (queue)",
+          "legendFormat": "{{queue}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Messages Consumed (rate/sec)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "nacked" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "rate(ruuster_messages_acked_total[$__rate_interval])",
+          "legendFormat": "acked",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(ruuster_messages_nacked_total[$__rate_interval]))",
+          "legendFormat": "nacked",
+          "refId": "B"
+        }
+      ],
+      "title": "Acks / Nacks (rate/sec)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "id": 12,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "ruuster_queues_count",
+          "legendFormat": "queues",
+          "refId": "A"
+        },
+        {
+          "expr": "ruuster_exchanges_count",
+          "legendFormat": "exchanges",
+          "refId": "B"
+        }
+      ],
+      "title": "Queues & Exchanges Count",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "id": 13,
+      "panels": [],
+      "title": "gRPC Performance",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 23 },
+      "id": 14,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(ruuster_grpc_requests_total[$__rate_interval])) by (method)",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "title": "gRPC Request Rate by Method",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
+      "id": 15,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(ruuster_grpc_request_duration_seconds_bucket[$__rate_interval])) by (le, method))",
+          "legendFormat": "p50 {{method}}",
+          "refId": "A"
+        }
+      ],
+      "title": "gRPC Latency p50 by Method",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "id": 16,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(ruuster_grpc_request_duration_seconds_bucket[$__rate_interval])) by (le, method))",
+          "legendFormat": "p95 {{method}}",
+          "refId": "A"
+        }
+      ],
+      "title": "gRPC Latency p95 by Method",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "error" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "id": 17,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(ruuster_grpc_requests_total{status=\"ok\"}[$__rate_interval]))",
+          "legendFormat": "success",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(ruuster_grpc_requests_total{status=\"error\"}[$__rate_interval]))",
+          "legendFormat": "error",
+          "refId": "B"
+        }
+      ],
+      "title": "gRPC Success vs Error Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "tags": ["ruuster", "message-queue"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Ruuster Message Queue",
+  "uid": "ruuster-dashboard",
+  "version": 1,
+  "weekStart": ""
+}

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: 'Ruuster'
+    orgId: 1
+    folder: ''
+    folderUid: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -5,5 +5,6 @@ datasources:
     type: prometheus
     access: proxy
     url: http://prometheus:9090
+    uid: prometheus
     isDefault: true
     editable: false

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "ruuster"
+    static_configs:
+      - targets: ["host.docker.internal:9090"]
+    metrics_path: /metrics
+    scrape_interval: 5s

--- a/queues/Cargo.toml
+++ b/queues/Cargo.toml
@@ -11,6 +11,7 @@ tonic = "0.11.0"
 tokio = { version = "1.37.0", features = ["tokio-macros", "macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.15", features = ["net"] }
 uuid = { version = "1.8.0", features = ["v4"] }
+metrics = "0.24"
 
 protos = { path = "../protos" }
 exchanges = { path = "../exchanges" }

--- a/queues/src/queues.rs
+++ b/queues/src/queues.rs
@@ -1,6 +1,7 @@
 use exchanges::{ExchangeContainer, ExchangeKind, ExchangeName, ExchangeType};
 
 use internals::{Message, Metadata};
+use metrics::{counter, gauge};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Status;
@@ -61,6 +62,9 @@ impl RuusterQueues {
 
         queues_write.insert(queue_name.to_owned(), Arc::new(Mutex::new(VecDeque::new())));
 
+        // Update metrics
+        gauge!("ruuster_queues_count").set(queues_write.len() as f64);
+
         info!("queue added");
         Ok(())
     }
@@ -77,6 +81,9 @@ impl RuusterQueues {
             warn!("queue does not exist");
             return Err(Status::not_found("queue does not exist"));
         }
+
+        // Update metrics
+        gauge!("ruuster_queues_count").set(queues_write.len() as f64);
 
         info!("queue removed");
         Ok(())
@@ -117,6 +124,9 @@ impl RuusterQueues {
 
         exchanges_write.insert(exchange_name.to_owned(), exchange_kind.create());
 
+        // Update metrics
+        gauge!("ruuster_exchanges_count").set(exchanges_write.len() as f64);
+
         info!("exchange added");
         Ok(())
     }
@@ -132,6 +142,10 @@ impl RuusterQueues {
             warn!("exchange does not exist");
             return Err(Status::not_found("exchange does not exist"));
         }
+
+        // Update metrics
+        gauge!("ruuster_exchanges_count").set(exchanges_write.len() as f64);
+
         Ok(())
     }
 
@@ -286,6 +300,13 @@ impl RuusterQueues {
                     Status::internal("failed to handle message")
                 })
         };
+
+        // Record metrics for produced messages
+        if result.is_ok() {
+            counter!("ruuster_messages_produced_total", "exchange" => exchange_name.clone())
+                .increment(1);
+        }
+
         info!("message handling completed");
         result
     }
@@ -475,6 +496,9 @@ impl RuusterQueues {
                         DEFAULT_ACK_DURATION,
                     )?;
                 }
+                // Record consumed message metric
+                counter!("ruuster_messages_consumed_total", "queue" => queue_name.clone())
+                    .increment(1);
                 info!(uuid = &msg.uuid, "consuming single message completed");
                 Ok(msg)
             }

--- a/queues/src/queues.rs
+++ b/queues/src/queues.rs
@@ -565,6 +565,9 @@ impl RuusterQueues {
                             error!(error=%e, "{}", msg);
                             return Status::internal(msg);
                         }
+                        // Record consumed message metric
+                        counter!("ruuster_messages_consumed_total", "queue" => queue_name.clone())
+                            .increment(1);
                         info!("message correctly sent over channel");
                     } else {
                         // tokio::task::yield_now().await;

--- a/ruuster_grpc/Cargo.toml
+++ b/ruuster_grpc/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = "1.37.0", features = ["tokio-macros", "macros", "rt-multi-th
 tokio-stream = { version = "0.1.15", features = ["net"] }
 tonic = "0.11.0"
 uuid = { version = "1.8.0", features = ["v4"]}
+metrics = "0.24"
 
 exchanges = { path = "../exchanges" }
 queues = { path = "../queues" }

--- a/ruuster_grpc/src/ruuster_grpc.rs
+++ b/ruuster_grpc/src/ruuster_grpc.rs
@@ -6,10 +6,20 @@ use protos::{
 };
 use queues::queues::RuusterQueues;
 
+use metrics::{counter, histogram};
+use std::time::Instant;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Response;
 use tonic::Status;
 use tracing::{info_span, instrument, Instrument};
+
+/// Record gRPC request metrics (counter and histogram)
+fn record_grpc_metrics(method: &'static str, status: &str, start: Instant) {
+    let duration = start.elapsed().as_secs_f64();
+    counter!("ruuster_grpc_requests_total", "method" => method, "status" => status.to_string())
+        .increment(1);
+    histogram!("ruuster_grpc_request_duration_seconds", "method" => method).record(duration);
+}
 
 pub struct RuusterQueuesGrpc(RuusterQueues);
 
@@ -32,11 +42,20 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         request: tonic::Request<QueueDeclareRequest>,
     ) -> Result<tonic::Response<Empty>, Status> {
+        let start = Instant::now();
         let request = request.into_inner();
         let queue_name = request.queue_name;
 
-        self.0.add_queue(&queue_name)?;
-        Ok(Response::new(Empty {}))
+        match self.0.add_queue(&queue_name) {
+            Ok(()) => {
+                record_grpc_metrics("queue_declare", "ok", start);
+                Ok(Response::new(Empty {}))
+            }
+            Err(e) => {
+                record_grpc_metrics("queue_declare", "error", start);
+                Err(e)
+            }
+        }
     }
 
     #[instrument(skip_all, fields(request=?request))]
@@ -44,14 +63,26 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         request: tonic::Request<ExchangeDeclareRequest>,
     ) -> Result<tonic::Response<Empty>, Status> {
+        let start = Instant::now();
         let request = request.into_inner();
         let (exchange_name, exchange_kind) = match request.exchange {
             Some(exchange) => (exchange.exchange_name, exchange.kind),
-            None => return Err(Status::failed_precondition("bad exchange request")),
+            None => {
+                record_grpc_metrics("exchange_declare", "error", start);
+                return Err(Status::failed_precondition("bad exchange request"));
+            }
         };
 
-        self.0.add_exchange(&exchange_name, exchange_kind.into())?;
-        Ok(Response::new(Empty {}))
+        match self.0.add_exchange(&exchange_name, exchange_kind.into()) {
+            Ok(()) => {
+                record_grpc_metrics("exchange_declare", "ok", start);
+                Ok(Response::new(Empty {}))
+            }
+            Err(e) => {
+                record_grpc_metrics("exchange_declare", "error", start);
+                Err(e)
+            }
+        }
     }
 
     #[instrument(skip_all)]
@@ -59,8 +90,17 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         _request: tonic::Request<Empty>,
     ) -> Result<tonic::Response<ListQueuesResponse>, tonic::Status> {
-        let queue_names = self.0.get_queues_list()?;
-        Ok(Response::new(ListQueuesResponse { queue_names }))
+        let start = Instant::now();
+        match self.0.get_queues_list() {
+            Ok(queue_names) => {
+                record_grpc_metrics("list_queues", "ok", start);
+                Ok(Response::new(ListQueuesResponse { queue_names }))
+            }
+            Err(e) => {
+                record_grpc_metrics("list_queues", "error", start);
+                Err(e)
+            }
+        }
     }
 
     #[instrument(skip_all)]
@@ -68,8 +108,17 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         _request: tonic::Request<Empty>,
     ) -> Result<tonic::Response<ListExchangesResponse>, tonic::Status> {
-        let exchange_names = self.0.get_exchanges_list()?;
-        Ok(Response::new(ListExchangesResponse { exchange_names }))
+        let start = Instant::now();
+        match self.0.get_exchanges_list() {
+            Ok(exchange_names) => {
+                record_grpc_metrics("list_exchanges", "ok", start);
+                Ok(Response::new(ListExchangesResponse { exchange_names }))
+            }
+            Err(e) => {
+                record_grpc_metrics("list_exchanges", "error", start);
+                Err(e)
+            }
+        }
     }
 
     #[instrument(skip_all, fields(request=?request))]
@@ -77,17 +126,34 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         request: tonic::Request<BindRequest>,
     ) -> Result<tonic::Response<Empty>, tonic::Status> {
+        let start = Instant::now();
         let request: BindRequest = request.into_inner();
 
         // check if requested queue and exchange exists
-        let _ = self.0.get_queue(&request.queue_name)?;
-        let _ = self.0.get_exchange(&request.exchange_name)?;
+        if let Err(e) = self.0.get_queue(&request.queue_name) {
+            record_grpc_metrics("bind", "error", start);
+            return Err(e);
+        }
+        if let Err(e) = self.0.get_exchange(&request.exchange_name) {
+            record_grpc_metrics("bind", "error", start);
+            return Err(e);
+        }
 
         let metadata = request.metadata.as_ref();
 
-        self.0
-            .bind_queue_to_exchange(&request.queue_name, &request.exchange_name, metadata)?;
-        Ok(Response::new(Empty {}))
+        match self
+            .0
+            .bind_queue_to_exchange(&request.queue_name, &request.exchange_name, metadata)
+        {
+            Ok(()) => {
+                record_grpc_metrics("bind", "ok", start);
+                Ok(Response::new(Empty {}))
+            }
+            Err(e) => {
+                record_grpc_metrics("bind", "error", start);
+                Err(e)
+            }
+        }
     }
 
     type ConsumeBulkStream = ReceiverStream<Result<protos::Message, Status>>;
@@ -99,6 +165,7 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         request: tonic::Request<ConsumeRequest>,
     ) -> Result<Response<Self::ConsumeBulkStream>, Status> {
+        let start = Instant::now();
         let request = request.into_inner();
         let span = info_span!(
             "consume_bulk",
@@ -110,6 +177,7 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         let result = async move { self.0.start_consuming_task(queue_name, auto_ack).await }
             .instrument(span)
             .await;
+        record_grpc_metrics("consume_bulk", "ok", start);
         Ok(Response::new(result))
     }
 
@@ -118,21 +186,31 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         request: tonic::Request<ConsumeRequest>,
     ) -> Result<Response<protos::Message>, Status> {
+        let start = Instant::now();
         let request = request.into_inner();
-        let message = self
+        match self
             .0
-            .consume_message(&request.queue_name, request.auto_ack)?;
-        let msg = protos::Message {
-            metadata: match message.metadata {
-                Some(m) => m.routing_key.map(|rk| protos::Metadata {
-                    routing_key: Some(RoutingKey { value: rk }),
-                }),
-                None => None,
-            },
-            payload: message.payload,
-            uuid: message.uuid,
-        };
-        Ok(Response::new(msg))
+            .consume_message(&request.queue_name, request.auto_ack)
+        {
+            Ok(message) => {
+                let msg = protos::Message {
+                    metadata: match message.metadata {
+                        Some(m) => m.routing_key.map(|rk| protos::Metadata {
+                            routing_key: Some(RoutingKey { value: rk }),
+                        }),
+                        None => None,
+                    },
+                    payload: message.payload,
+                    uuid: message.uuid,
+                };
+                record_grpc_metrics("consume_one", "ok", start);
+                Ok(Response::new(msg))
+            }
+            Err(e) => {
+                record_grpc_metrics("consume_one", "error", start);
+                Err(e)
+            }
+        }
     }
 
     #[instrument(skip_all, fields(request=?request))]
@@ -140,15 +218,26 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         request: tonic::Request<ProduceRequest>,
     ) -> Result<Response<Empty>, Status> {
+        let start = Instant::now();
         let request = request.into_inner();
         let metadata = Some(internals::Metadata {
             created_at: None,
             dead_letter: None,
             routing_key: request.metadata.map(|m| m.routing_key.unwrap().value),
         });
-        self.0
-            .forward_message(request.payload, &request.exchange_name, metadata)?;
-        Ok(Response::new(Empty {}))
+        match self
+            .0
+            .forward_message(request.payload, &request.exchange_name, metadata)
+        {
+            Ok(_) => {
+                record_grpc_metrics("produce", "ok", start);
+                Ok(Response::new(Empty {}))
+            }
+            Err(e) => {
+                record_grpc_metrics("produce", "error", start);
+                Err(e)
+            }
+        }
     }
 
     #[instrument(skip_all)]
@@ -156,9 +245,18 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         _request: tonic::Request<AckRequest>,
     ) -> Result<Response<Empty>, Status> {
+        let start = Instant::now();
         let request = _request.into_inner();
-        self.0.apply_message_ack(request.uuid)?;
-        Ok(Response::new(Empty {}))
+        match self.0.apply_message_ack(request.uuid) {
+            Ok(()) => {
+                record_grpc_metrics("ack_message", "ok", start);
+                Ok(Response::new(Empty {}))
+            }
+            Err(e) => {
+                record_grpc_metrics("ack_message", "error", start);
+                Err(e)
+            }
+        }
     }
 
     #[instrument(skip_all, fields(request=?request))]
@@ -166,9 +264,18 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         request: tonic::Request<AckMessageBulkRequest>,
     ) -> Result<Response<Empty>, Status> {
+        let start = Instant::now();
         let request = request.into_inner();
-        self.0.apply_message_bulk_ack(&request.uuids)?;
-        Ok(Response::new(Empty {}))
+        match self.0.apply_message_bulk_ack(&request.uuids) {
+            Ok(()) => {
+                record_grpc_metrics("ack_message_bulk", "ok", start);
+                Ok(Response::new(Empty {}))
+            }
+            Err(e) => {
+                record_grpc_metrics("ack_message_bulk", "error", start);
+                Err(e)
+            }
+        }
     }
 
     #[instrument(skip_all, fields(request=?request))]
@@ -176,9 +283,18 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         request: tonic::Request<NackRequest>,
     ) -> Result<Response<Empty>, Status> {
+        let start = Instant::now();
         let request = request.into_inner();
-        self.0.apply_message_nack(request.uuid, request.requeue)?;
-        Ok(Response::new(Empty {}))
+        match self.0.apply_message_nack(request.uuid, request.requeue) {
+            Ok(()) => {
+                record_grpc_metrics("nack_message", "ok", start);
+                Ok(Response::new(Empty {}))
+            }
+            Err(e) => {
+                record_grpc_metrics("nack_message", "error", start);
+                Err(e)
+            }
+        }
     }
 
     #[instrument(skip_all, fields(request=?request))]
@@ -186,14 +302,23 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         request: tonic::Request<NackMessageBulkRequest>,
     ) -> Result<Response<Empty>, Status> {
+        let start = Instant::now();
         let request = request.into_inner();
         let nacks: Vec<(String, bool)> = request
             .nacks
             .into_iter()
             .map(|n| (n.uuid, n.requeue))
             .collect();
-        self.0.apply_message_bulk_nack(&nacks)?;
-        Ok(Response::new(Empty {}))
+        match self.0.apply_message_bulk_nack(&nacks) {
+            Ok(()) => {
+                record_grpc_metrics("nack_message_bulk", "ok", start);
+                Ok(Response::new(Empty {}))
+            }
+            Err(e) => {
+                record_grpc_metrics("nack_message_bulk", "error", start);
+                Err(e)
+            }
+        }
     }
 
     #[instrument(skip_all, fields(request=?request))]
@@ -201,13 +326,22 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         request: tonic::Request<UnbindRequest>,
     ) -> Result<Response<Empty>, Status> {
+        let start = Instant::now();
         let request = request.into_inner();
-        self.0.unbind_queue_from_exchange(
+        match self.0.unbind_queue_from_exchange(
             &request.queue_name,
             &request.exchange_name,
             request.metadata.as_ref(),
-        )?;
-        Ok(Response::new(Empty {}))
+        ) {
+            Ok(()) => {
+                record_grpc_metrics("unbind", "ok", start);
+                Ok(Response::new(Empty {}))
+            }
+            Err(e) => {
+                record_grpc_metrics("unbind", "error", start);
+                Err(e)
+            }
+        }
     }
 
     #[instrument(skip_all, fields(request=?request))]
@@ -215,9 +349,18 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         request: tonic::Request<RemoveQueueRequest>,
     ) -> Result<Response<Empty>, Status> {
+        let start = Instant::now();
         let request = request.into_inner();
-        self.0.remove_queue(&request.queue_name)?;
-        Ok(Response::new(Empty {}))
+        match self.0.remove_queue(&request.queue_name) {
+            Ok(()) => {
+                record_grpc_metrics("remove_queue", "ok", start);
+                Ok(Response::new(Empty {}))
+            }
+            Err(e) => {
+                record_grpc_metrics("remove_queue", "error", start);
+                Err(e)
+            }
+        }
     }
 
     #[instrument(skip_all, fields(request=?request))]
@@ -225,9 +368,18 @@ impl ruuster::ruuster_server::Ruuster for RuusterQueuesGrpc {
         &self,
         request: tonic::Request<RemoveExchangeRequest>,
     ) -> Result<Response<Empty>, Status> {
+        let start = Instant::now();
         let request = request.into_inner();
-        self.0.remove_exchange(&request.exchange_name)?;
-        Ok(Response::new(Empty {}))
+        match self.0.remove_exchange(&request.exchange_name) {
+            Ok(()) => {
+                record_grpc_metrics("remove_exchange", "ok", start);
+                Ok(Response::new(Empty {}))
+            }
+            Err(e) => {
+                record_grpc_metrics("remove_exchange", "error", start);
+                Err(e)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Implements Prometheus metrics for monitoring Ruuster, addressing #48.

- Adds `/metrics` endpoint on port 9090 for Prometheus scraping
- Adds `/health` endpoint for liveness checks
- Instruments all gRPC methods with request counters and latency histograms
- Tracks queue/exchange counts, message throughput, and ack/nack rates

## Metrics Exposed

| Metric | Type | Labels |
|--------|------|--------|
| `ruuster_grpc_requests_total` | Counter | `method`, `status` |
| `ruuster_grpc_request_duration_seconds` | Histogram | `method` |
| `ruuster_messages_produced_total` | Counter | `exchange` |
| `ruuster_messages_consumed_total` | Counter | `queue` |
| `ruuster_messages_acked_total` | Counter | - |
| `ruuster_messages_nacked_total` | Counter | `requeue` |
| `ruuster_queues_count` | Gauge | - |
| `ruuster_exchanges_count` | Gauge | - |

## Configuration

- `RUUSTER_METRICS_ADDR` - Address for metrics server (default: `127.0.0.1:9090`)
- Prometheus config included in `prometheus.yml`
- Docker Compose updated with Prometheus service

## Testing

- `cargo build` - passes
- `cargo test` - 27 tests pass
- `cargo clippy` - no new warnings

Closes #48

<img width="1912" height="1185" alt="image" src="https://github.com/user-attachments/assets/81adb39e-0217-49df-9b06-a850627de3e9" />
<img width="1912" height="1185" alt="image" src="https://github.com/user-attachments/assets/5086b27a-0816-4771-bc3d-b2424ccea25a" />
<img width="1912" height="1185" alt="image" src="https://github.com/user-attachments/assets/435d9754-b877-4e17-9cc4-434d5c4ac574" />


## How to run?
1. `docker compose --profile monitoring up -d`
2. `./launch_demo_chat.sh`
3. send some messages
4. go to grafana a `[http://localhost:3000](http://localhost:3000)` admin/admin
